### PR TITLE
fix gralloc_priv.h error

### DIFF
--- a/camera/QCamera2/Android.mk
+++ b/camera/QCamera2/Android.mk
@@ -123,6 +123,8 @@ LOCAL_HEADER_LIBRARIES += libandroid_sensor_headers
 LOCAL_HEADER_LIBRARIES += libcutils_headers
 LOCAL_HEADER_LIBRARIES += libsystem_headers
 LOCAL_HEADER_LIBRARIES += libhardware_headers
+LOCAL_HEADER_LIBRARIES += display_headers
+
 
 #HAL 1.0 Include paths
 LOCAL_C_INCLUDES += \


### PR DESCRIPTION
Since gralloc_priv.h is no longer copied, include display_headers
to pick it up again